### PR TITLE
librdkafka config support

### DIFF
--- a/run.py
+++ b/run.py
@@ -2,7 +2,7 @@ import genesis.streaming as gs
 
 message = { 'hello': 'world' }
 
-with gs.open("kafka://localhost/test1", "rw", start_at="earliest", format="json") as stream:
+with gs.open("kafka://localhost/test1", "rw", start_at="earliest", format="json", config="kafkacat.conf") as stream:
 	stream.write(message)
 
 #with gs.open("kafka://localhost/test1", "r", start_at="earliest", format="json") as stream:


### PR DESCRIPTION
Added config=[fn|dict] keyword argument to genesis.streaming.open(), which
allows passing of librdkafka configs to producer/consumer constructors.
See https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md for
the list of available options.

The most common usage is to pass encryption configuration and authentication
credentials.  For example, to open an SSL-encrypted connection to a broker,
one may open the stream as follows:

```
import genesis.streaming as gs

with gs.open("kafka://localhost/test1", "rw", start_at="earliest", format="json", config="kafkacat.conf") as stream:
	...
```

with

```
$ cat kafkacat.conf
ssl.ca.location=/tmp/shared/tls/cacert.pem
security.protocol=SASL_SSL
sasl.mechanism=PLAIN
sasl.username=test
sasl.password=test-pass
```

(note that `kafkacat.conf` uses the same format as kafkacat).

Note: instead of a filename, a `dict` with options can be passed.