### PR TITLE
Raise a ValueError instead of ArgumentError for bad Kafka URL

### DIFF
--- a/genesis/streaming.py
+++ b/genesis/streaming.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import sys, io, time, argparse, string, signal, itertools, os.path
+import sys, io, time, string, signal, itertools, os.path
 import json, base64
 import fastavro, fastavro.write
 
@@ -94,7 +94,7 @@ def parse_kafka_url(val, allow_no_topic=False):
 		(groupid_brokers, topics) = val.split('/')
 	except ValueError:
 		if not allow_no_topic:
-			raise argparse.ArgumentError(self, f'A kafka:// url must be of the form kafka://[groupid@]broker[,broker2[,...]]/topicspec[,topicspec[,...]].')
+			raise ValueError(f'A kafka:// url must be of the form kafka://[groupid@]broker[,broker2[,...]]/topicspec[,topicspec[,...]].')
 		else:
 			groupid_brokers, topics = val, None
 
@@ -104,7 +104,7 @@ def parse_kafka_url(val, allow_no_topic=False):
 		(groupid, brokers) = (None, groupid_brokers)
 
 	topics = topics.split(',') if topics is not None else []
-	
+
 	return (groupid, brokers, topics)
 
 


### PR DESCRIPTION
This library attempts to be middleware which can be used in any context - either in a CLI, or in a headless process. ArgumentError is not quite right here - and we can't construct one anyway, since we
don't have access to an 'argument.' As a result, the code prior to this commit would actually raise a NameError because 'self' is not defined.

Fixes #11.