### PR TITLE
Add authentication support

### DIFF
--- a/doc/api/api.rst
+++ b/doc/api/api.rst
@@ -6,4 +6,5 @@ genesis-client API
 .. toctree::
     :maxdepth: 2
 
+    auth
     streaming

--- a/genesis/auth.py
+++ b/genesis/auth.py
@@ -1,6 +1,20 @@
 #!/usr/bin/env python
 
+from enum import Enum
+
 import certifi
+
+
+class SASLMethod(Enum):
+    """SASL method to use for authentication.
+    """
+
+    PLAIN = 1
+    SCRAM_SHA_256 = 2
+    SCRAM_SHA_512 = 3
+
+    def __str__(self):
+        return self.name.replace("_", "-")
 
 
 class SASLAuth(object):
@@ -16,20 +30,17 @@ class SASLAuth(object):
         Password to authenticate with.
     ssl : `bool`, optional
         Whether to enable SSL (enabled by default).
-    method : `str`, optional
-        The SASL method to authenticate, default = PLAIN.
-        Options are [PLAIN, SCRAM-SHA-256, SCRAM-SHA-512].
+    method : `SASLMethod`, optional
+        The SASL method to authenticate, default = SASLMethod.PLAIN.
+        See valid SASL methods in SASLMethod.
     ssl_ca_location : `str`, optional
         If using SSL via a self-signed cert, a path/location
         to the certificate.
 
     """
 
-    _methods = ["PLAIN", "SCRAM-SHA-256", "SCRAM-SHA-512"]
-
-    def __init__(self, user, password, ssl=True, method="PLAIN", **kwargs):
-        self._method = method.upper()
-        assert self._method in self._methods
+    def __init__(self, user, password, ssl=True, method=SASLMethod.PLAIN, **kwargs):
+        self._method = method
 
         # set up SSL options
         if ssl:
@@ -46,7 +57,7 @@ class SASLAuth(object):
             self._config = {"security.protocol": "SASL_PLAINTEXT"}
 
         # set up SASL options
-        self._config["sasl.mechanism"] = self._method
+        self._config["sasl.mechanism"] = str(self._method)
         self._config["sasl.username"] = user
         self._config["sasl.password"] = password
 

--- a/genesis/auth.py
+++ b/genesis/auth.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+
+import certifi
+
+
+class SASLAuth(object):
+    """Attach SASL-based authentication to a client.
+
+    Returns client-based auth options when called.
+
+    Parameters
+    ----------
+    user : `str`
+        Username to authenticate with.
+    password : `str`
+        Password to authenticate with.
+    ssl : `bool`, optional
+        Whether to enable SSL (enabled by default).
+    method : `str`, optional
+        The SASL method to authenticate, default = PLAIN.
+        Options are [PLAIN, SCRAM-SHA-256, SCRAM-SHA-512].
+    ssl_ca_location : `str`, optional
+        If using SSL via a self-signed cert, a path/location
+        to the certificate.
+
+    """
+
+    _methods = ["PLAIN", "SCRAM-SHA-256", "SCRAM-SHA-512"]
+
+    def __init__(self, user, password, ssl=True, method="PLAIN", **kwargs):
+        self._method = method.upper()
+        assert self._method in self._methods
+
+        # set up SSL options
+        if ssl:
+            if "ssl_ca_location" in kwargs:
+                ssl_cert = kwargs["ssl_ca_location"]
+            else:
+                ssl_cert = certifi.where()
+
+            self._config = {
+                "security.protocol": "SASL_SSL",
+                "ssl.ca.location": ssl_cert,
+            }
+        else:
+            self._config = {"security.protocol": "SASL_PLAINTEXT"}
+
+        # set up SASL options
+        self._config["sasl.mechanism"] = self._method
+        self._config["sasl.username"] = user
+        self._config["sasl.password"] = password
+
+    def __call__(self):
+        return self._config

--- a/genesis/streaming.py
+++ b/genesis/streaming.py
@@ -103,7 +103,7 @@ class AlertBroker:
 	c = None
 	p = None
 
-	def __init__(self, broker_url, mode='r', start_at='latest', format='avro', metadata=False, config=None):
+	def __init__(self, broker_url, mode='r', start_at='latest', format='avro', auth=None, metadata=False, config=None):
 		self.groupid, self.brokers, self.topics = parse_kafka_url(broker_url)
 
 		# mode can be 'r', 'w', or 'rw'; other characters are ignored
@@ -130,6 +130,10 @@ class AlertBroker:
 					parser = configparser.ConfigParser()
 					parser.read_string("[root]\n" + fp.read())
 					cfg = dict(parser["root"])
+
+		# load authentication settings, if given
+		if auth:
+			cfg = {**cfg, **auth()}
 
 		if 'r' in mode:
 			ccfg={ **cfg,

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - fastavro
     - python-confluent-kafka
     - tqdm
+    - certifi
 
 test:
   imports:

--- a/setup.py
+++ b/setup.py
@@ -79,5 +79,5 @@ setup(name='adc',
       author_email='mjuric@astro.washington.edu',
       license='MIT',
       packages=['genesis'],
-      install_requires=['fastavro', 'confluent-kafka', 'tqdm'],
+      install_requires=['fastavro', 'confluent-kafka', 'certifi', 'tqdm'],
       zip_safe=False)


### PR DESCRIPTION
This PR addresses #3, to support Kafka-based authentication in the AlertBroker.

I added a new module, auth.py, which supports Requests-style authentication classes. One concrete example is implemented to handle SASL-based authentication.

Example:
```
from genesis.auth import SASLAuth

auth = SASLAuth('test', 'test-pass', ssl_ca_location='/tmp/shared/tls/cacert.pem')

kafka_url = "kafka://localhost:9092/sometopic"
with stream.open(kafka_url, 'w', format='json', auth=auth) as s:
    s.write({"this is": "a message"})
```

Sensible defaults are chosen such as SSL being enabled by default. `ssl_ca_location` is needed if you're using a self-signed certificate. If that's not specified but SSL is enabled, it'll look in the default CA location on your machine with `certifi`.

I added the `certifi` library as a dependency, which should be easy to satisfy since `requests` also depends on it, and can be installed via yum/apt.

Closes #3.