### PR TITLE
Overhaul project development workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,11 @@ help :
 	@echo '  make format                run code formatter, giving a diff for recommended changes'
 	@echo '  make doc                   make documentation'
 	@echo '  make changelog             update changelog based on version'
-	@echo '  make dist                  make binary and source packages'
-	@echo '  make dist-check            verify binary and source packages'
-	@echo '  make upload                upload to PyPI'
+	@echo '  make pypi-dist             make binary and source packages for PyPI'
+	@echo '  make pypi-dist-check       verify binary and source packages for PyPI'
+	@echo '  make pypi-upload           upload to PyPI'
+	@echo '  make conda-build           make binary and source packages for conda-forge'
+	@echo '  make conda-upload          upload to conda-forge'
 	@echo
 
 VERSION ?= $(shell python setup.py --version)
@@ -41,14 +43,23 @@ changelog :
 	sed -i 's@## \[Unreleased]@## \[Unreleased]\n\n## \[$(VERSION)] - $(shell date +'%Y-%m-%d')@' CHANGELOG.md
 	sed -i 's@.*\[Unreleased]:.*@\[Unreleased]: $(REPO_URL)/compare/v$(VERSION)...HEAD\n[$(VERSION)]: $(REPO_URL)/releases/tag/v$(VERSION)@' CHANGELOG.md
 
-.PHONY: dist
-dist :
+
+.PHONY: pypi-dist
+pypi-dist :
 	python setup.py sdist bdist_wheel
 
-.PHONY: dist-check
-dist-check:
+.PHONY: pypi-dist-check
+pypi-dist-check:
 	twine check dist/*
 
-.PHONY: upload
-upload:
+.PHONY: pypi-upload
+pypi-upload:
 	twine upload dist/*
+
+.PHONY: conda-build
+conda-build:
+	conda build -c defaults -c conda-forge ./recipe
+
+.PHONY: conda-upload
+conda-upload:
+	anaconda upload $(shell conda build ./recipe --output)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,54 @@
+.PHONY: help
+help :
+	@echo
+	@echo 'Commands:'
+	@echo
+	@echo '  make test                  run unit tests'
+	@echo '  make lint                  run linter'
+	@echo '  make format                run code formatter, giving a diff for recommended changes'
+	@echo '  make doc                   make documentation'
+	@echo '  make changelog             update changelog based on version'
+	@echo '  make dist                  make binary and source packages'
+	@echo '  make dist-check            verify binary and source packages'
+	@echo '  make upload                upload to PyPI'
+	@echo
+
+VERSION ?= $(shell python setup.py --version)
+REPO_URL = https://github.com/astronomy-commons/genesis-client
+
+.PHONY: test
+test :
+	python -m pytest -v
+
+.PHONY: lint
+lint :
+# stop the build if there are Python syntax errors or undefined names
+	flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+# exit-zero treats all errors as warnings
+	flake8 . --count --exit-zero --max-complexity=10 --max-line-length=100 --statistics
+
+.PHONY: format
+format :
+# show diff via black
+	black . --diff
+
+.PHONY: doc
+doc :
+	cd doc && make html
+
+.PHONY: changelog
+changelog :
+	sed -i 's@## \[Unreleased]@## \[Unreleased]\n\n## \[$(VERSION)] - $(shell date +'%Y-%m-%d')@' CHANGELOG.md
+	sed -i 's@.*\[Unreleased]:.*@\[Unreleased]: $(REPO_URL)/compare/v$(VERSION)...HEAD\n[$(VERSION)]: $(REPO_URL)/releases/tag/v$(VERSION)@' CHANGELOG.md
+
+.PHONY: dist
+dist :
+	python setup.py sdist bdist_wheel
+
+.PHONY: dist-check
+dist-check:
+	twine check dist/*
+
+.PHONY: upload
+upload:
+	twine upload dist/*

--- a/README.md
+++ b/README.md
@@ -4,18 +4,42 @@ Libraries making it easy to access astronomy data commons resources.
 
 ## Developer notes
 
+### Setup
+
+To prepare for development, run `pip install --editable ".[dev]"` from within
+the repo directory. This will install all dependencies, including those using
+during development workflows.
+
+This project expects you to use a `pip`-centric workflow for development on the
+project itself. It gets released to conda, but we don't attempt to record
+development-time dependencies like linters through conda tools.
+
+### Code Workflow
+
+Write code, making changes.
+
+Use `make format` to reformat your code to comply with
+[black](https://github.com/psf/black).
+
+Use `make lint` to catch common mistakes.
+
+Use `make test` to run tests.
+
+Once satisfied with all three of those, push your changes and open a PR.
+
 ### Tag, build, and upload to PyPI and Conda
 
+Tag a new version:
 ```
 git tag -s -a v0.x.x
 ```
 
-```
-python setup.py sdist bdist_wheel
-twine upload dist/*
-```
+Build and release:
 
 ```
-conda build -c defaults -c conda-forge recipe
-anaconda upload --user scimma /Users/mjuric/anaconda3/conda-bld/noarch/adc-0.0.2-py_0.tar.bz2
+make pypi-dist
+make pypi-dist-check
+make pypi-upload
+make conda-build
+make conda-upload
 ```

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ the repo directory. This will install all dependencies, including those using
 during development workflows.
 
 This project expects you to use a `pip`-centric workflow for development on the
-project itself. It gets released to conda, but we don't attempt to record
-development-time dependencies like linters through conda tools.
+project itself. If you're using conda, then use the conda environment's `pip` to
+install development dependencies, as described above.
 
 ### Code Workflow
 

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -1,6 +1,0 @@
-fastavro
-python-confluent-kafka
-tqdm
-conda-build
-twine
-anaconda-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-fastavro
-confluent-kafka
-tqdm
-twine

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,24 @@ def git_version():
       fmt = '{tag}.dev{commitcount}+g{gitsha}{dirtytag}'
       return fmt.format(tag=tag, commitcount=count, gitsha=sha.lstrip('g'), dirtytag=dirtytag)
 
+# requirements
+install_requires = [
+      "fastavro",
+      "confluent-kafka",
+      "tqdm",
+      "certifi"
+]
+
+dev_requires = [
+      "black",
+      "flake8",
+      "flake8-black",
+      "pytest",
+      "sphinx",
+      "sphinx_rtd_theme",
+      "twine",
+]
+
 
 setup(name='adc',
       version=git_version(),
@@ -79,5 +97,8 @@ setup(name='adc',
       author_email='mjuric@astro.washington.edu',
       license='MIT',
       packages=['genesis'],
-      install_requires=['fastavro', 'confluent-kafka', 'certifi', 'tqdm'],
+      install_requires=install_requires,
+      extras_require={
+            "dev": dev_requires,
+      },
       zip_safe=False)


### PR DESCRIPTION
Add a Makefile which is the entrypoint for testing, linting, formatting, and release. This Makefile is a copy from github.com/scimma/client_library, originally written by @myNameIsPatrick (thanks!).

Document these new Make commands in README.md.

Add the Make-based tools to setup.py.

Move away from a requirements.txt workflow, and towards one based on using 'extras_require' directive in setup.py. I like putting requirements in one place (it still bothers me a bit that `conda` has its own requirements list, but c'est la vie).

---
I don't know much about it, but pipenv looks like Yet Another Way to express dependency information, but it seems better tuned to development workflows. Is it worth trying?