### PR TITLE
Add a GH Workflow for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - name: Check out the code
+      uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Check that the package is pip-installable
+      run: |
+        python -m pip install --upgrade pip
+        pip install .[dev]
+
+    - name: Lint
+      run: make lint
+
+    - name: Test
+      run: make test


### PR DESCRIPTION
Adds a basic workflow, cribbed from https://github.com/scimma/client_library.

This uses the integration tests added in #26. Astonishingly, they seem to work just fine.