### PR TITLE
Use certifi by default

### DIFF
--- a/adc/streaming.py
+++ b/adc/streaming.py
@@ -14,6 +14,7 @@ import fastavro.write
 from confluent_kafka import Consumer, KafkaError, TopicPartition, Producer
 from contextlib import contextmanager
 from collections import namedtuple
+import certifi
 
 import configparser
 
@@ -158,7 +159,7 @@ class AlertBroker:
 
         if 'w' in mode:
             if len(self.topics) > 1:
-                raise ValueError(f"an AlertBroker in write mode can only have "
+                raise ValueError("an AlertBroker in write mode can only have "
                                  + f"one topic in its URL, but found {len(self.topics)} topics")
             pcfg = {**cfg,
                     'bootstrap.servers': ",".join(self.brokers),

--- a/adc/streaming.py
+++ b/adc/streaming.py
@@ -122,6 +122,11 @@ class AlertBroker:
         # load librdkafka configuration file, if given configurable properties:
         # https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
         cfg = dict()
+
+        # Use certifi's SSL certificates by default. This can get overwritten by
+        # later config loading.
+        cfg["ssl.ca.location"] = certifi.where()
+
         if config is not None:
             if isinstance(config, dict):
                 cfg = config

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ install_requires = [
     "fastavro",
     "confluent-kafka",
     "tqdm",
-    "certifi"
+    "certifi>=2020.04.05.1"
 ]
 
 dev_requires = [


### PR DESCRIPTION
Kafka brokers on the internet will use SSL typically. Connecting to them requires verifying the server's SSL certificate. That verification will only succeed if OpenSSL thinks the certificate looks legit, which will only succeed if the cert is signed by a known-good certificate authority. OpenSSL's set of known-good certificate authorities is determined by `librdkafka`, which should be compiled with a pass to the OS's trust store.

On some platforms (notably CentOS 7), the `librdkafka` doesn't know where the trust store is, so it can't verify server certificates. This leads to confusing behavior for clients.

Updating root certificates is usually an OS-specific maneuver, but `certifi` is a Python package which distributes Mozilla's set of known-good certificate authority identities. This package is up-to-date and
well-maintained, so using it should improve our package's portability.

By default, we can use certifi's bundle of certs, and then most brokers with legitimate SSL server certificates will be verified correctly. 

It's still possible to override this choice if a user has a self-signed certificate or something strange.