### PR TITLE
Fix certifi config loading

### DIFF
--- a/adc/streaming.py
+++ b/adc/streaming.py
@@ -128,10 +128,6 @@ class AlertBroker:
         # https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
         cfg = dict()
 
-        # Use certifi's SSL certificates by default. This can get overwritten by
-        # later config loading.
-        cfg["ssl.ca.location"] = certifi.where()
-
         if config is not None:
             if isinstance(config, dict):
                 cfg = config
@@ -147,6 +143,9 @@ class AlertBroker:
         # load authentication settings, if given
         if auth:
             cfg = {**cfg, **auth()}
+
+        if "ssl.ca.location" not in cfg:
+            cfg["ssl.ca.location"] = certifi.where()
 
         if 'r' in mode:
             ccfg = {**cfg,


### PR DESCRIPTION
As worked out by testing on a centos box (we should probably make an integration test for this). Thanks for pointing out the bug, @shereenElSayed.

The issue is that we end up overriding the configuration dictionary sometimes, depending on its type (!). This code badly needs to be refactored.