### PR TITLE
producer.py: increase producer timeout to 10s

### DIFF
--- a/adc/producer.py
+++ b/adc/producer.py
@@ -73,7 +73,7 @@ class ProducerConfig:
 
     # produce_timeout sets the maximum amount of time that the backend can take
     # to send a message to Kafka. Use a value of 0 to never timeout.
-    produce_timeout = timedelta(seconds=2)
+    produce_timeout = timedelta(seconds=10)
 
     def _to_confluent_kafka(self) -> Dict:
         config = {


### PR DESCRIPTION
See title. There were issues using the 2s timeout since that also includes the time spent to initially connect to a broker, so this has been increased to 10s. Note that the default timeout if not set is 300s.

Ideally, there would be two separate timeouts:
* 10s timeout to connect to a broker
 * while connected, 2s timeout to send a message

but I didn't see anything more fine-grained in looking at the various librdkafka settings. Could've have easily missed the magic setting though.