### PR TITLE
consumer.py: fix version display in log warnings if using latest offsets

### DIFF
--- a/adc/consumer.py
+++ b/adc/consumer.py
@@ -57,7 +57,7 @@ class Consumer:
                 if librdkafka_version < "1.5.0":
                     self.logger.warn(
                         "In librdkafka before v1.5, LATEST offsets have buggy behavior; you may "
-                        "not receive data (your librdkafka version is {librdkafka_version}). See "
+                        f"not receive data (your librdkafka version is {librdkafka_version}). See "
                         "https://github.com/confluentinc/confluent-kafka-dotnet/issues/1254.")
                 tp.offset = confluent_kafka.OFFSET_END
             else:


### PR DESCRIPTION
This PR fixes the log messages when using the latest offset.

Before:
```
In librdkafka before v1.5, LATEST offsets have buggy behavior; you may not receive data (your librdkafka version is {librdkafka_version}). See https://github.com/confluentinc/confluent-kafka-dotnet/issues/1254.
```

After:
```
In librdkafka before v1.5, LATEST offsets have buggy behavior; you may not receive data (your librdkafka version is 1.4.2). See https://github.com/confluentinc/confluent-kafka-dotnet/issues/1254.
```