### PR TITLE
setup.py, meta.yaml: remove fastavro dependency as it's no longer used

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,12 +11,10 @@ requirements:
   build:
     - pytest
     - python
-    - fastavro
     - python-confluent-kafka
     - tqdm
   run:
     - python
-    - fastavro
     - python-confluent-kafka
     - tqdm
     - certifi

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,6 @@ def git_version():
 
 # requirements
 install_requires = [
-    "fastavro",
     "confluent-kafka",
     "dataclasses ; python_version < '3.7'",
     "tqdm",


### PR DESCRIPTION
This PR just removes the `fastavro` dependency throughout as it's no longer used directly within adc-streaming.