### PR TITLE
Obey offsets stored in Kafka for existing groups

### DIFF
--- a/adc/consumer.py
+++ b/adc/consumer.py
@@ -167,7 +167,6 @@ class Consumer:
 class ConsumerStartPosition(enum.Enum):
     EARLIEST = 1
     LATEST = 2
-    PRODUCER = 3
 
     def __str__(self):
         return self.name.lower()

--- a/adc/consumer.py
+++ b/adc/consumer.py
@@ -2,7 +2,7 @@ import dataclasses
 import enum
 import logging
 from datetime import timedelta
-from typing import Dict, Iterator, List, Optional, Set, Union
+from typing import Dict, Iterator, List, Optional, Set
 
 import confluent_kafka  # type: ignore
 import confluent_kafka.admin  # type: ignore
@@ -187,9 +187,8 @@ class ConsumerConfig:
     # was marked done with consumer.mark_done, regardless of this setting. This
     # is only used when the position in the stream is unknown.
     #
-    # This can either be a logical offset via a ConsumerStartPosition value, or
-    # it can be a specific offset as an integer.
-    start_at: Union[ConsumerStartPosition, int] = ConsumerStartPosition.EARLIEST
+    # This is specified as a logical offset via a ConsumerStartPosition value.
+    start_at: ConsumerStartPosition = ConsumerStartPosition.EARLIEST
 
     # Authentication package to pass in to read from Kafka.
     auth: Optional[SASLAuth] = None

--- a/adc/consumer.py
+++ b/adc/consumer.py
@@ -44,11 +44,6 @@ class Consumer:
                 topic=topic,
                 partition=partition_id,
             )
-            # Get the current offsets stored in Kafka. The high offset
-            # is the offset of the last message + 1.
-            low, high = self._consumer.get_watermark_offsets(tp, timeout=timeout.total_seconds())
-            tp.offset = high - 1
-
             assignment.append(tp)
 
         self.logger.debug("registering topic assignment")

--- a/adc/io.py
+++ b/adc/io.py
@@ -13,7 +13,7 @@ logger = logging.getLogger("adc-streaming")
 def open(url: str,
          mode: str = 'r',
          auth: Optional[auth.SASLAuth] = None,
-         start_at: Union[consumer.ConsumerStartPosition, int] = consumer.ConsumerStartPosition.EARLIEST,  # noqa: E501
+         start_at: consumer.ConsumerStartPosition = consumer.ConsumerStartPosition.EARLIEST,  # noqa: E501
          read_forever: bool = True,
          ) -> Union[producer.Producer, Iterable[confluent_kafka.Message]]:
     group_id, broker_addresses, topics = kafka.parse_kafka_url(url)
@@ -43,7 +43,7 @@ def _open_consumer(
         broker_addresses: List[str],
         topics: List[str],
         auth: Optional[auth.SASLAuth],
-        start_at: Union[consumer.ConsumerStartPosition, int],
+        start_at: consumer.ConsumerStartPosition,
         read_forever: bool,
 ) -> Iterable[confluent_kafka.Message]:
     client = consumer.Consumer(consumer.ConsumerConfig(

--- a/tests/test_kafka_integration.py
+++ b/tests/test_kafka_integration.py
@@ -128,6 +128,7 @@ class KafkaIntegrationTestCase(unittest.TestCase):
             broker_urls=[self.kafka.address],
             group_id="test_consumer_1",
             auth=self.kafka.auth,
+            read_forever=False,
             start_at=adc.consumer.ConsumerStartPosition.EARLIEST,
         ))
         consumer_1.subscribe(topic)
@@ -138,7 +139,7 @@ class KafkaIntegrationTestCase(unittest.TestCase):
         self.assertEqual(len(batch_1), len(msgs_1))
         for expected, actual in zip(batch_1, msgs_1):
             self.assertEqual(actual.topic(), topic)
-            self.assertEqual(actual.value(), expected)
+            self.assertEqual(actual.value().decode(), expected)
 
         # Write second batch of messages.
         batch_2 = [
@@ -156,13 +157,14 @@ class KafkaIntegrationTestCase(unittest.TestCase):
         self.assertEqual(len(batch_2), len(msgs_1))
         for expected, actual in zip(batch_2, msgs_1):
             self.assertEqual(actual.topic(), topic)
-            self.assertEqual(actual.value(), expected)
+            self.assertEqual(actual.value().decode(), expected)
 
         # Start second consumer, also reading from earliest offset.
         consumer_2 = adc.consumer.Consumer(adc.consumer.ConsumerConfig(
             broker_urls=[self.kafka.address],
             group_id="test_consumer_2",
             auth=self.kafka.auth,
+            read_forever=False,
             start_at=adc.consumer.ConsumerStartPosition.EARLIEST,
         ))
         consumer_2.subscribe(topic)
@@ -173,7 +175,7 @@ class KafkaIntegrationTestCase(unittest.TestCase):
         self.assertEqual(len(batch_1 + batch_2), len(msgs_2))
         for expected, actual in zip(batch_1 + batch_2, msgs_2):
             self.assertEqual(actual.topic(), topic)
-            self.assertEqual(actual.value(), expected)
+            self.assertEqual(actual.value().decode(), expected)
 
     def test_consume_not_forever(self):
         topic = "test_consume_not_forever"

--- a/tests/test_kafka_integration.py
+++ b/tests/test_kafka_integration.py
@@ -112,6 +112,69 @@ class KafkaIntegrationTestCase(unittest.TestCase):
         self.assertEqual(msg.topic(), topic)
         self.assertEqual(msg.value(), b"message 4")
 
+    def test_consume_stored_offsets(self):
+        # Write first batch of messages.
+        topic = "test_stored_offsets"
+        batch_1 = [
+            "message 1",
+            "message 2",
+            "message 3",
+            "message 4",
+        ]
+        simple_write_msgs(self.kafka, topic, batch_1)
+
+        # Start first consumer, reading from earliest offset.
+        consumer_1 = adc.consumer.Consumer(adc.consumer.ConsumerConfig(
+            broker_urls=[self.kafka.address],
+            group_id="test_consumer_1",
+            auth=self.kafka.auth,
+            start_at=adc.consumer.ConsumerStartPosition.EARLIEST,
+        ))
+        consumer_1.subscribe(topic)
+        stream_1 = consumer_1.stream()
+        msgs_1 = [msg for msg in stream_1]
+
+        # Check that all messages from first batch are processed.
+        self.assertEqual(len(batch_1), len(msgs_1))
+        for expected, actual in zip(batch_1, msgs_1):
+            self.assertEqual(actual.topic(), topic)
+            self.assertEqual(actual.value(), expected)
+
+        # Write second batch of messages.
+        batch_2 = [
+            "message 5",
+            "message 6",
+            "message 7",
+        ]
+        simple_write_msgs(self.kafka, topic, batch_2)
+
+        # Read more messages from first consumer. This should now
+        # only read from the stored offset, so that only the second
+        # batch is processed.
+        stream_1 = consumer_1.stream()
+        msgs_1 = [msg for msg in stream_1]
+        self.assertEqual(len(batch_2), len(msgs_1))
+        for expected, actual in zip(batch_2, msgs_1):
+            self.assertEqual(actual.topic(), topic)
+            self.assertEqual(actual.value(), expected)
+
+        # Start second consumer, also reading from earliest offset.
+        consumer_2 = adc.consumer.Consumer(adc.consumer.ConsumerConfig(
+            broker_urls=[self.kafka.address],
+            group_id="test_consumer_2",
+            auth=self.kafka.auth,
+            start_at=adc.consumer.ConsumerStartPosition.EARLIEST,
+        ))
+        consumer_2.subscribe(topic)
+        stream_2 = consumer_2.stream()
+        msgs_2 = [msg for msg in stream_2]
+
+        # Now check that messages from both batches are processed.
+        self.assertEqual(len(batch_1 + batch_2), len(msgs_2))
+        for expected, actual in zip(batch_1 + batch_2, msgs_2):
+            self.assertEqual(actual.topic(), topic)
+            self.assertEqual(actual.value(), expected)
+
     def test_consume_not_forever(self):
         topic = "test_consume_not_forever"
         simple_write_msg(self.kafka, topic, "message 1")


### PR DESCRIPTION
This PR should address #41. In `Consumer.subscribe()`, instead of making an assignment based on the `start_at` position in the configuration, it'll call `get_watermark_offsets()` to grab the current offset in the consumer to make that assignment. In the case there is no offset stored, it'll pull the value stored via "auto.offset.reset" in the configured consumer.

I have also moved where the warning about using the LATEST offset is raised since this check isn't being done in the same location anymore.

Closes #41.