### PR TITLE
Expose low-level Kafka error details through KafkaException

### DIFF
--- a/adc/errors.py
+++ b/adc/errors.py
@@ -43,10 +43,13 @@ def raise_delivery_errors(kafka_error: confluent_kafka.KafkaError,
 class KafkaException(Exception):
     @classmethod
     def from_kafka_error(cls, error):
-        return cls(error.name(), error.str())
+        return cls(error)
 
-    def __init__(self, name, message):
-        self.name = name
-        self.message = message
-        msg = f"Error communicating with Kafka: code={name} {message}"
+    def __init__(self, error):
+        self.error = error
+        self.name = error.name()
+        self.reason = error.str()
+        self.retriable = error.retriable()
+        self.fatal = error.fatal()
+        msg = f"Error communicating with Kafka: code={self.name} {self.reason}"
         super(KafkaException, self).__init__(msg)


### PR DESCRIPTION
In order to help callers retry on transient failures, this PR makes it easier to access the raw KafkaError object on a KafkaException. Callers can use the `retriable` field to know whether an error is transient, for example.

Related: https://github.com/scimma/hop-client/issues/140