### PR TITLE
Refactor consumer auto-commit

### DIFF
--- a/adc/consumer.py
+++ b/adc/consumer.py
@@ -67,7 +67,6 @@ class Consumer:
         resumed from this point in the future.
         """
         self._consumer.commit(msg, asynchronous=True)
-        self._consumer.poll(1e-3) # wait at most a millisecond
 
     def stream(self,
                autocommit: bool = True,


### PR DESCRIPTION
These changes make commiting offsets to a consumer group (marking messages read) work simply, including the auto-commit convenience feature. 

The millisecond timeout for `poll` in `mark_done` is arbitrary; the purpose is simply to cause `poll` to be called periodically so that callbacks are triggered, without having to wait until the user makes a final call to flush (if indedd the user ever does), without introducing too much extra latency. 