### PR TITLE
Set delivery callbacks per-message, not per-client

### DIFF
--- a/adc/io.py
+++ b/adc/io.py
@@ -5,7 +5,7 @@ from typing import Iterable, List, Optional, Union
 
 import confluent_kafka  # type: ignore
 
-from adc import auth, consumer, errors, kafka, producer
+from adc import auth, consumer, kafka, producer
 
 logger = logging.getLogger("adc-streaming")
 
@@ -71,5 +71,4 @@ def _open_producer(
         broker_urls=broker_addresses,
         topic=topic,
         auth=auth,
-        delivery_callback=errors.raise_delivery_errors,
     ))

--- a/adc/producer.py
+++ b/adc/producer.py
@@ -24,13 +24,14 @@ class Producer:
 
     def write(self,
               msg: Union[bytes, 'Serializable'],
-              headers: Optional[Union[dict,list]] = None,
+              headers: Optional[Union[dict, list]] = None,
               delivery_callback: Optional[DeliveryCallback] = log_delivery_errors) -> None:
         if isinstance(msg, Serializable):
             msg = msg.serialize()
         self.logger.debug("writing message to %s", self.conf.topic)
         if delivery_callback is not None:
-            self._producer.produce(self.conf.topic, msg, headers=headers, on_delivery=delivery_callback)
+            self._producer.produce(self.conf.topic, msg, headers=headers,
+                                   on_delivery=delivery_callback)
         else:
             self._producer.produce(self.conf.topic, msg, headers=headers)
 

--- a/adc/producer.py
+++ b/adc/producer.py
@@ -24,12 +24,13 @@ class Producer:
 
     def write(self,
               msg: Union[bytes, 'Serializable'],
-              headers: Optional[Union[dict,list]] = None) -> None:
+              headers: Optional[Union[dict,list]] = None,
+              delivery_callback: Optional[DeliveryCallback] = log_delivery_errors) -> None:
         if isinstance(msg, Serializable):
             msg = msg.serialize()
         self.logger.debug("writing message to %s", self.conf.topic)
-        if self.conf.delivery_callback is not None:
-            self._producer.produce(self.conf.topic, msg, headers=headers, on_delivery=self.conf.delivery_callback)
+        if delivery_callback is not None:
+            self._producer.produce(self.conf.topic, msg, headers=headers, on_delivery=delivery_callback)
         else:
             self._producer.produce(self.conf.topic, msg, headers=headers)
 
@@ -69,7 +70,6 @@ class ProducerConfig:
     broker_urls: List[str]
     topic: str
     auth: Optional[SASLAuth] = None
-    delivery_callback: Optional[DeliveryCallback] = log_delivery_errors
     error_callback: Optional[ErrorCallback] = log_client_errors
 
     # produce_timeout sets the maximum amount of time that the backend can take


### PR DESCRIPTION
The librdkafa author [suggests](https://github.com/confluentinc/confluent-kafka-python/pull/1167#discussion_r711978100) that callbacks should have bound into them the message with which they're associated, which greatly simplifies reacting to network disruption and ensuring mesage delivery, but `adc` currently forces the use of a single callback for all messages sent with a given `Producer`. This change relaxes that constraint, enabling full use of the underlying confluent-kafka feature. 