### PR TITLE
Use setuptools_scm for version management

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
     - name: Check that the package is pip-installable
       run: |
         python -m pip install --upgrade pip
+        pip install --upgrade setuptools setuptools_scm wheel
         pip install .[dev]
 
     - name: Lint

--- a/adc/__init__.py
+++ b/adc/__init__.py
@@ -1,0 +1,11 @@
+try:
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:
+    # NOTE: remove after dropping support for Python < 3.8
+    from importlib_metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("adc-streaming")
+except PackageNotFoundError:
+    # package is not installed
+    pass

--- a/setup.py
+++ b/setup.py
@@ -1,76 +1,11 @@
 from setuptools import setup
 
-##
-# Infer version from git tag information
-##
-
-
-def git_version():
-    # Uses the following logic:
-    #
-    # * If the current commit has an annotated tags, the version is simply the tag with
-    #   the leading 'v' removed.
-    #
-    # * If the current commit is past an annotated tag, the version is constructed at:
-    #
-    #    '{tag+1}.dev{commitcount}+{gitsha}'
-    #
-    #  where {commitcount} is the number of commits after the tag (obtained with `git describe`)
-    #  and {tag+1} is the tag version incremented by one (i.e., if tag=0.0.1, it's 0.0.2). This
-    #  is needed because .dev tags compare as less than non-.dev tags, per PEP-440.
-    #
-    # * If there are no annotated tags in the past, the version is:
-    #
-    #    '0.0.0.dev{commitcount}+{gitsha}'
-    #
-    # Inspired by https://github.com/pyfidelity/setuptools-git-version
-    # Creates PEP-440 compliant versions
-
-    from subprocess import check_output
-
-    command = 'git describe --tags --long --dirty --always'
-    version = check_output(command.split()).decode('utf-8').strip()
-
-    parts = version.split('-')
-    if len(parts) in (3, 4):
-        dirty = len(parts) == 4
-        tag, count, sha = parts[:3]
-        if not tag.startswith('v'):
-            raise Exception(
-                "Annotated tags on the repository must begin with the letter 'v'. Please fix this then try building agains.")
-        tag = tag[1:]
-        if count == '0' and not dirty:
-            return tag
-    elif len(parts) in (1, 2):
-        tag = "0.0.0"
-        dirty = len(parts) == 2
-        sha = parts[0]
-        # Number of commits since the beginning of the current branch
-        count = check_output(
-            "git rev-list --count HEAD".split()).decode('utf-8').strip()
-
-    # this will be a .dev version; assume the version is of the form
-    # major[.minor[.patchlevel]], and increment the patchlevel by 1.
-    # because minor and/or patchlevel are optional
-    (major, minor, patchlevel) = (tag + ".0.0").split('.')[:3]
-    patchlevel = str(int(patchlevel) + 1)
-    tag = '.'.join((major, minor, patchlevel))
-
-    # if the working directory is dirty, append a '.dYYYYMMDD' tag
-    if dirty:
-        import time
-        dirtytag = time.strftime('.d%Y%m%d')
-    else:
-        dirtytag = ''
-
-    fmt = '{tag}.dev{commitcount}+g{gitsha}{dirtytag}'
-    return fmt.format(tag=tag, commitcount=count, gitsha=sha.lstrip('g'), dirtytag=dirtytag)
-
 
 # requirements
 install_requires = [
     "confluent-kafka",
     "dataclasses ; python_version < '3.7'",
+    "importlib-metadata ; python_version < '3.8'",
     "tqdm",
     "certifi>=2020.04.05.1"
 ]
@@ -90,7 +25,6 @@ dev_requires = [
 
 
 setup(name='adc-streaming',
-      version=git_version(),
       description='Astronomy Data Commons streaming client libraries',
       long_description=open("README.md").read(),
       long_description_content_type="text/markdown",
@@ -110,4 +44,6 @@ setup(name='adc-streaming',
       extras_require={
           "dev": dev_requires,
       },
+      setup_requires=['setuptools_scm'],
+      use_scm_version=True,
       zip_safe=False)


### PR DESCRIPTION
This PR switches to setuptools_scm for versioning, resolving issues where the version was not exported when creating source/binary distributions. This was a blocker to create conda-forge packages.