### PR TITLE
Do not raise exceptions inside the logging callback

### DIFF
--- a/adc/errors.py
+++ b/adc/errors.py
@@ -19,7 +19,6 @@ def log_client_errors(kafka_error: confluent_kafka.KafkaError):
         logger.warn("client is currently disconnected from all brokers")
     else:
         logger.error(f"internal kafka error: {kafka_error}")
-        raise(KafkaException.from_kafka_error(kafka_error))
 
 
 DeliveryCallback = Callable[[confluent_kafka.KafkaError, confluent_kafka.Message], None]


### PR DESCRIPTION
Since confluent-kafka-python does not properly support exceptions thrown in callbacks, having a callback raise them is not helpful. 