### PR TITLE
Add OAUTHBEARER/OIDC support

### DIFF
--- a/adc/consumer.py
+++ b/adc/consumer.py
@@ -9,6 +9,7 @@ import confluent_kafka.admin  # type: ignore
 
 from .auth import SASLAuth
 from .errors import ErrorCallback, log_client_errors
+from .oidc import set_oauth_cb
 
 
 class Consumer:
@@ -272,4 +273,5 @@ class ConsumerConfig:
 
         if self.auth is not None:
             config.update(self.auth())
+        set_oauth_cb(config)
         return config

--- a/adc/consumer.py
+++ b/adc/consumer.py
@@ -2,13 +2,14 @@ import dataclasses
 import enum
 import logging
 from datetime import timedelta
+from multiprocessing import context
 from typing import Dict, Iterable, Iterator, List, Optional, Set, Union
 
 import confluent_kafka  # type: ignore
 import confluent_kafka.admin  # type: ignore
 
 from .auth import SASLAuth
-from .errors import ErrorCallback, log_client_errors
+from .errors import ErrorCallback, log_client_errors, catch_kafka_version_support_errors
 
 
 class Consumer:
@@ -19,7 +20,8 @@ class Consumer:
     def __init__(self, conf: 'ConsumerConfig') -> None:
         self.logger = logging.getLogger("adc-streaming.consumer")
         self.conf = conf
-        self._consumer = confluent_kafka.Consumer(conf._to_confluent_kafka())
+        with catch_kafka_version_support_errors():
+            self._consumer = confluent_kafka.Consumer(conf._to_confluent_kafka())
 
     def subscribe(self,
                   topics: Union[str, Iterable],

--- a/adc/consumer.py
+++ b/adc/consumer.py
@@ -2,14 +2,13 @@ import dataclasses
 import enum
 import logging
 from datetime import timedelta
-from multiprocessing import context
 from typing import Dict, Iterable, Iterator, List, Optional, Set, Union
 
 import confluent_kafka  # type: ignore
 import confluent_kafka.admin  # type: ignore
 
 from .auth import SASLAuth
-from .errors import ErrorCallback, log_client_errors, catch_kafka_version_support_errors
+from .errors import ErrorCallback, log_client_errors
 
 
 class Consumer:
@@ -20,8 +19,7 @@ class Consumer:
     def __init__(self, conf: 'ConsumerConfig') -> None:
         self.logger = logging.getLogger("adc-streaming.consumer")
         self.conf = conf
-        with catch_kafka_version_support_errors():
-            self._consumer = confluent_kafka.Consumer(conf._to_confluent_kafka())
+        self._consumer = confluent_kafka.Consumer(conf._to_confluent_kafka())
 
     def subscribe(self,
                   topics: Union[str, Iterable],

--- a/adc/errors.py
+++ b/adc/errors.py
@@ -1,7 +1,9 @@
+from contextlib import contextmanager
 import logging
 from typing import Callable
 
 import confluent_kafka  # type: ignore
+from packaging.version import Version
 
 logger = logging.getLogger("adc-streaming")
 
@@ -52,3 +54,23 @@ class KafkaException(Exception):
         self.fatal = error.fatal()
         msg = f"Error communicating with Kafka: code={self.name} {self.reason}"
         super(KafkaException, self).__init__(msg)
+
+
+@contextmanager
+def catch_kafka_version_support_errors():
+    try:
+        yield
+    except confluent_kafka.KafkaException as e:
+        err, *_ = e.args
+        librdkafka_version, *_ = confluent_kafka.libversion()
+        if (
+            err.code() == confluent_kafka.KafkaError._INVALID_ARG
+            and any(err.str() == f'No such configuration property: "{key}"'
+                    for key in ['sasl.oauthbearer.client.id',
+                                'sasl.oauthbearer.client.secret',
+                                'sasl.oauthbearer.method',
+                                'sasl.oauthbearer.token.endpoint.url'])
+            and Version(librdkafka_version) < Version('1.9.0')
+        ):
+            raise RuntimeError(f'OpenID Connect support requires librdkafka >= 1.9.0, but you have {librdkafka_version}. Please install a newer version of confluent-kafka.') from e
+        raise

--- a/adc/oidc.py
+++ b/adc/oidc.py
@@ -1,0 +1,25 @@
+def set_oauth_cb(config):
+    """Implement client support for KIP-768 OpenID Connect.
+
+    Apache Kafka 3.1.0 supports authentication using OpenID Client Credentials.
+    Native support for Python is coming in the next release of librdkafka
+    (version 1.9.0). Meanwhile, this is a pure Python implementation of the
+    refresh token callback.
+    """
+    if config.pop('sasl.oauthbearer.method') != 'oidc':
+        return
+
+    client_id = config.pop('sasl.oauthbearer.client.id')
+    client_secret = config.pop('sasl.oauthbearer.client.secret')
+    scope = config.pop('sasl.oauthbearer.scope', None)
+    token_endpoint = config.pop('sasl.oauthbearer.token.endpoint.url')
+
+    from authlib.integrations.requests_client import OAuth2Session
+    session = OAuth2Session(client_id, client_secret, scope=scope)
+    
+    def oauth_cb(*_, **__):
+        token = session.fetch_token(
+            token_endpoint, grant_type='client_credentials')
+        return token['access_token'], token['expires_at']
+
+    config['oauth_cb'] = oauth_cb

--- a/adc/producer.py
+++ b/adc/producer.py
@@ -8,7 +8,7 @@ import confluent_kafka  # type: ignore
 
 from .auth import SASLAuth
 from .errors import (DeliveryCallback, ErrorCallback, log_client_errors,
-                     log_delivery_errors)
+                     log_delivery_errors, catch_kafka_version_support_errors)
 
 
 class Producer:
@@ -20,7 +20,8 @@ class Producer:
         self.logger = logging.getLogger("adc-streaming.producer")
         self.conf = conf
         self.logger.debug(f"connecting to producer with config {conf._to_confluent_kafka()}")
-        self._producer = confluent_kafka.Producer(conf._to_confluent_kafka())
+        with catch_kafka_version_support_errors():
+            self._producer = confluent_kafka.Producer(conf._to_confluent_kafka())
 
     def write(self,
               msg: Union[bytes, 'Serializable'],

--- a/adc/producer.py
+++ b/adc/producer.py
@@ -9,6 +9,7 @@ import confluent_kafka  # type: ignore
 from .auth import SASLAuth
 from .errors import (DeliveryCallback, ErrorCallback, log_client_errors,
                      log_delivery_errors)
+from .oidc import set_oauth_cb
 
 
 class Producer:
@@ -114,6 +115,7 @@ class ProducerConfig:
             config["error_cb"] = self.error_callback
         if self.auth is not None:
             config.update(self.auth())
+        set_oauth_cb(config)
         return config
 
 

--- a/adc/producer.py
+++ b/adc/producer.py
@@ -8,7 +8,7 @@ import confluent_kafka  # type: ignore
 
 from .auth import SASLAuth
 from .errors import (DeliveryCallback, ErrorCallback, log_client_errors,
-                     log_delivery_errors, catch_kafka_version_support_errors)
+                     log_delivery_errors)
 
 
 class Producer:
@@ -20,8 +20,7 @@ class Producer:
         self.logger = logging.getLogger("adc-streaming.producer")
         self.conf = conf
         self.logger.debug(f"connecting to producer with config {conf._to_confluent_kafka()}")
-        with catch_kafka_version_support_errors():
-            self._producer = confluent_kafka.Producer(conf._to_confluent_kafka())
+        self._producer = confluent_kafka.Producer(conf._to_confluent_kafka())
 
     def write(self,
               msg: Union[bytes, 'Serializable'],

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,11 @@ from setuptools import setup
 
 # requirements
 install_requires = [
+    "authlib",  # FIXME: drop after next release of confluent-kafka with OIDC support
     "confluent-kafka",
     "dataclasses ; python_version < '3.7'",
     "importlib-metadata ; python_version < '3.8'",
+    "requests",  # FIXME: drop after next release of confluent-kafka with OIDC support
     "tqdm",
     "certifi>=2020.04.05.1"
 ]

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ dev_requires = [
     "docker",
     "flake8",
     "isort",
+    "packaging",
     "pytest",
     "pytest-timeout",
     "pytest-integration",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ dev_requires = [
     "docker",
     "flake8",
     "isort",
-    "packaging",
     "pytest",
     "pytest-timeout",
     "pytest-integration",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,36 @@
+import pytest
+
+from adc.auth import SASLAuth, SASLMethod
+
+
+@pytest.mark.parametrize('auth,expected_config', [
+    [
+        SASLAuth(
+            'test', 'test-pass',
+            token_endpoint='https://example.com/oauth2/token'
+        ),
+        {
+            'sasl.mechanism': 'OAUTHBEARER',
+            'sasl.oauthbearer.client.id': 'test',
+            'sasl.oauthbearer.client.secret': 'test-pass',
+            'sasl.oauthbearer.method': 'oidc',
+            'sasl.oauthbearer.token.endpoint.url': 'https://example.com/oauth2/token',
+            'security.protocol': 'SASL_SSL'
+        }
+    ],
+    [
+        SASLAuth(
+            'test', 'test-pass',
+        ),
+        {
+            'sasl.mechanism': 'PLAIN',
+            'sasl.username': 'test',
+            'sasl.password': 'test-pass',
+            'security.protocol': 'SASL_SSL'
+        }
+    ]
+])
+def test_auth(auth, expected_config):
+    # Check that the key/value pairs in expected_config are a subset
+    # of the key/value pairs in auth._config.
+    assert expected_config.items() <= auth._config.items()


### PR DESCRIPTION
Add OAUTHBEARER / OpenID Connect (OIDC) support as described in [KIP-768]. This is the authentication mechanism used by the GCN/TACH Kafka broker.

* The `SASLMethod` enum gets a new member, `OAUTHBEARER`.
* The `SASLAuth` constructor gets a new optional keyword argument, `token_endpoint`.
* The presence of the `token_endpoint` keyword argument causes the default SASL method to change to `OAUTHBEARER` and the oauthbearer method to change to `oidc`, because this option is required for OpenID Connect and ignored for all other auth methods.
* In OIDC mode, the `username` and `password` positional arguments are interpreted as the client ID and client secret.

[KIP-768]: https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=186877575