### PR TITLE
Work around librdkafka crash when using oauth_cb

### DIFF
--- a/adc/consumer.py
+++ b/adc/consumer.py
@@ -22,6 +22,9 @@ class Consumer:
         self.logger = logging.getLogger("adc-streaming.consumer")
         self.conf = conf
         self._consumer = confluent_kafka.Consumer(conf._to_confluent_kafka())
+        # Workaround for https://github.com/edenhill/librdkafka/issues/3263.
+        # Remove once confluent-kafka-python 1.9.0 has been released.
+        self._consumer.poll(0)
 
     def subscribe(self,
                   topics: Union[str, Iterable],

--- a/adc/producer.py
+++ b/adc/producer.py
@@ -22,6 +22,9 @@ class Producer:
         self.conf = conf
         self.logger.debug(f"connecting to producer with config {conf._to_confluent_kafka()}")
         self._producer = confluent_kafka.Producer(conf._to_confluent_kafka())
+        # Workaround for https://github.com/edenhill/librdkafka/issues/3263.
+        # Remove once confluent-kafka-python 1.9.0 has been released.
+        self._producer.poll(0)
 
     def write(self,
               msg: Union[bytes, 'Serializable'],


### PR DESCRIPTION
Work around edenhill/librdkafka#3263. Remove once confluent-kafka 1.9.0 has been released.