### PR TITLE
Add pyproject.toml file for PEP 517 builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,4 @@ setup(name='adc-streaming',
       extras_require={
           "dev": dev_requires,
       },
-      setup_requires=['setuptools_scm'],
-      use_scm_version=True,
       zip_safe=False)


### PR DESCRIPTION
This file is now required for building Python packages, in the most general case.