### PR TITLE
Revert compression to being off by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - name: Check out the code

--- a/adc/producer.py
+++ b/adc/producer.py
@@ -104,7 +104,7 @@ class ProducerConfig:
     # between attempts to reconnect to Kafka.
     reconnect_max_time: timedelta = timedelta(seconds=10)
 
-    compression_type: Optional[Union[Literal['gzip'], Literal['snappy'], Literal['lz4'], Literal['zstd']]] = 'zstd'
+    compression_type: Optional[Union[Literal['gzip'], Literal['snappy'], Literal['lz4'], Literal['zstd']]] = None
 
     # maximum message size, before compression
     message_max_bytes: Optional[int] = None


### PR DESCRIPTION
Turning on compression by default caused problems for multiple users, and just doesn't make much sense when it is unknowable whether the user will be sending messages which are small or large, compressible or incompressible. 