### PR TITLE
Allow specifying logical offset or datetime start position on Consumer.stream()

### DIFF
--- a/adc/consumer.py
+++ b/adc/consumer.py
@@ -1,7 +1,7 @@
 import dataclasses
 import enum
 import logging
-from datetime import timedelta
+from datetime import datetime, timedelta
 import threading
 from typing import Dict, Iterable, Iterator, List, Optional, Set, Union
 from collections import defaultdict
@@ -13,6 +13,17 @@ from .auth import SASLAuth
 from .errors import ErrorCallback, log_client_errors
 from .oidc import set_oauth_cb
 
+
+class LogicalOffset(enum.IntEnum):
+    BEGINNING = confluent_kafka.OFFSET_BEGINNING
+    EARLIEST = confluent_kafka.OFFSET_BEGINNING
+
+    END = confluent_kafka.OFFSET_END
+    LATEST = confluent_kafka.OFFSET_END
+
+    STORED = confluent_kafka.OFFSET_STORED
+
+    INVALID = confluent_kafka.OFFSET_INVALID
 
 class Consumer:
     conf: 'ConsumerConfig'
@@ -30,7 +41,8 @@ class Consumer:
 
     def subscribe(self,
                   topics: Union[str, Iterable],
-                  timeout: timedelta = timedelta(seconds=10)):
+                  timeout: timedelta = timedelta(seconds=10),
+                  start_at: Union[datetime, LogicalOffset] = LogicalOffset.INVALID):
         """Subscribes to topics for consuming. This method doesn't use Kafka's
         Consumer Groups; it assigns all partitions manually to this
         process.
@@ -39,6 +51,11 @@ class Consumer:
         """
         if isinstance(topics, str):
             topics = [topics]
+
+        if isinstance(start_at, datetime):
+            offset = int(start_at.timestamp() * 1000) # offsets_for_times takes milliseconds
+        else:
+            offset = start_at
 
         assignment = []
         for topic in topics:
@@ -54,8 +71,13 @@ class Consumer:
                 tp = confluent_kafka.TopicPartition(
                     topic=topic,
                     partition=partition_id,
+                    offset=offset
                 )
                 assignment.append(tp)
+
+        if isinstance(start_at, datetime):
+            self.logger.debug(f"calculating offsets for given time")
+            assignment = self._consumer.offsets_for_times(assignment)
 
         self.logger.debug("registering topic assignment")
         self._consumer.assign(assignment)
@@ -201,14 +223,19 @@ class Consumer:
         """ Close the consumer, ending its subscriptions. """
         self._consumer.close()
 
-
-class ConsumerStartPosition(enum.Enum):
+# Used to be called ConsumerStartPosition, though this was confusing because
+# it only affects "auto.offset.reset" not the start position for a call to
+# consume.
+class ConsumerResetPosition(enum.Enum):
     EARLIEST = 1
     LATEST = 2
 
     def __str__(self):
         return self.name.lower()
 
+# Alias to the old name
+# TODO: Remove alias on the next breaking release
+ConsumerStartPosition = ConsumerResetPosition
 
 @dataclasses.dataclass
 class ConsumerConfig:
@@ -225,8 +252,13 @@ class ConsumerConfig:
     # was marked done with consumer.mark_done, regardless of this setting. This
     # is only used when the position in the stream is unknown.
     #
-    # This is specified as a logical offset via a ConsumerStartPosition value.
-    start_at: ConsumerStartPosition = ConsumerStartPosition.EARLIEST
+    # You can force reading at a logical offset or datetime with the "start_at"
+    # argument to Consumer.subscribe().
+    #
+    # This is specified via a ConsumerResetPosition value.
+    #
+    # TODO: rename on next breaking release
+    start_at: ConsumerResetPosition = ConsumerResetPosition.EARLIEST
 
     # Authentication package to pass in to read from Kafka.
     auth: Optional[SASLAuth] = None
@@ -269,13 +301,13 @@ class ConsumerConfig:
             "reconnect.backoff.max.ms": as_ms(self.reconnect_max_time),
             "reconnect.backoff.ms": as_ms(self.reconnect_backoff_time),
         }
-        if self.start_at is ConsumerStartPosition.EARLIEST:
+        if self.start_at is ConsumerResetPosition.EARLIEST:
             default_topic_config = config.get("default.topic.config", {})
             default_topic_config = {
                 "auto.offset.reset": "EARLIEST",
             }
             config["default.topic.config"] = default_topic_config
-        elif self.start_at is ConsumerStartPosition.LATEST:
+        elif self.start_at is ConsumerResetPosition.LATEST:
             # FIXME: librdkafka has a bug in offset handling - it caches
             # "OFFSET_END", and will repeatedly move to the end of the
             # topic. See https://github.com/edenhill/librdkafka/pull/2876 -


### PR DESCRIPTION
Previously, the only way to specify the position to stream from was via the `auto.offset.reset` key, which only affected the first read with a given group id (otherwise it always used committed offsets).

This PR introduces a new parameter `start_at` to `Consumer.stream()` that takes either a kafka defined logical offset `END = -2, BEGINNING = -1, INVALID = -1001, STORED = -1000` or a `datetime` object. The correct offsets for the datetime are looked up with `confluent_kafka.Consumer.offsets_for_times`. The best way I could find to do this was by reassigning the topics on a call to `Consumer.stream` since `seek` will fail before the server is updated with the local state and we can't poll without consuming data.

hop-client passes keyword args down to `Consumer.stream` from `hop.io.Consumer.read`, so no changes are needed on that front.

To reduce confusion with the `start_at` option in `ConsumerConfig`, I've renamed the Enum to `ConsumerResetPosition` (`ConsumerDefaultPosition` might also work), with an alias for backward compatibility for now. I suggest renaming the config property and using the Kafka reserved offsets (-2, -1) in `LogicalOffset` for the next breaking change/major release.

New test cases were developed. I also made some fixes to previously broken test cases, and made `test_consume_stored_offsets` more comprehensive. (note: for some reason the timestamps reported from kafka in the scimma/server image are 48h offset from the host's time?)