### PR TITLE
Update confluent-kafka version to skip recent buggy releases

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # requirements
 install_requires = [
     "authlib",  # FIXME: drop after next release of confluent-kafka with OIDC support
-    "confluent-kafka",
+    "confluent-kafka >= 1.6.1, != 2.1.0, != 2.1.1",
     "dataclasses ; python_version < '3.7'",
     "importlib-metadata ; python_version < '3.8'",
     "requests",  # FIXME: drop after next release of confluent-kafka with OIDC support


### PR DESCRIPTION
confluent-kafka 2.1.0 and 2.1.1 segfault when connecting to GCN. See https://github.com/confluentinc/confluent-kafka-python/issues/1547.