### PR TITLE
Update doc strings and comments for confluent-kafka workarounds

### DIFF
--- a/adc/consumer.py
+++ b/adc/consumer.py
@@ -23,7 +23,7 @@ class Consumer:
         self.logger = logging.getLogger("adc-streaming.consumer")
         self.conf = conf
         self._consumer = confluent_kafka.Consumer(conf._to_confluent_kafka())
-        # Workaround for https://github.com/edenhill/librdkafka/issues/3871.
+        # Workaround for https://github.com/confluentinc/librdkafka/issues/3753#issuecomment-1058272987.
         # FIXME: Remove once fixed upstream, or on removal of oauth_cb.
         self._consumer.poll(0)
         self._stop_event = threading.Event()

--- a/adc/oidc.py
+++ b/adc/oidc.py
@@ -2,9 +2,11 @@ def set_oauth_cb(config):
     """Implement client support for KIP-768 OpenID Connect.
 
     Apache Kafka 3.1.0 supports authentication using OpenID Client Credentials.
-    Native support for Python is coming in the next release of librdkafka
-    (version 1.9.0). Meanwhile, this is a pure Python implementation of the
-    refresh token callback.
+    Native support for Python is still incomplete due to this issue:
+    https://github.com/confluentinc/librdkafka/issues/3751
+
+    Meanwhile, this is a pure Python implementation of the refresh token
+    callback.
     """
     if config.pop('sasl.oauthbearer.method', None) != 'oidc':
         return

--- a/adc/producer.py
+++ b/adc/producer.py
@@ -27,7 +27,7 @@ class Producer:
         self.conf = conf
         self.logger.debug(f"connecting to producer with config {conf._to_confluent_kafka()}")
         self._producer = confluent_kafka.Producer(conf._to_confluent_kafka())
-        # Workaround for https://github.com/edenhill/librdkafka/issues/3871.
+        # Workaround for https://github.com/confluentinc/librdkafka/issues/3753#issuecomment-1058272987.
         # FIXME: Remove once fixed upstream, or on removal of oauth_cb.
         self._producer.poll(0)
 


### PR DESCRIPTION
See https://github.com/nasa-gcn/gcn-kafka-python/pull/23.