### PR TITLE
Multi-topic publishing

### DIFF
--- a/adc/__init__.py
+++ b/adc/__init__.py
@@ -1,8 +1,8 @@
 try:
-    from importlib.metadata import version, PackageNotFoundError
+    from importlib.metadata import PackageNotFoundError, version
 except ImportError:
     # NOTE: remove after dropping support for Python < 3.8
-    from importlib_metadata import version, PackageNotFoundError
+    from importlib_metadata import PackageNotFoundError, version
 
 try:
     __version__ = version("adc-streaming")

--- a/adc/consumer.py
+++ b/adc/consumer.py
@@ -1,12 +1,13 @@
 import dataclasses
 import enum
 import logging
-from datetime import datetime, timedelta
 import threading
+from collections import defaultdict
+from datetime import datetime, timedelta
 # Imports from typing are deprecated as of Python 3.9 but required for
 # compatibility with earlier versions
-from typing import Dict, Iterable, Iterator, List, Optional, Set, Union, Collection
-from collections import defaultdict
+from typing import (Collection, Dict, Iterable, Iterator, List, Optional, Set,
+                    Union)
 
 import confluent_kafka  # type: ignore
 import confluent_kafka.admin  # type: ignore
@@ -14,6 +15,7 @@ import confluent_kafka.admin  # type: ignore
 from .auth import SASLAuth
 from .errors import ErrorCallback, log_client_errors
 from .oidc import set_oauth_cb
+
 
 class LogicalOffset(enum.IntEnum):
     BEGINNING = confluent_kafka.OFFSET_BEGINNING
@@ -25,6 +27,7 @@ class LogicalOffset(enum.IntEnum):
     STORED = confluent_kafka.OFFSET_STORED
 
     INVALID = confluent_kafka.OFFSET_INVALID
+
 
 class Consumer:
     conf: 'ConsumerConfig'
@@ -99,14 +102,15 @@ class Consumer:
             self._consumer.commit(msg, asynchronous=False)
 
     def _offsets_for_position(self, partitions: Collection[confluent_kafka.TopicPartition],
-                              position: Union[datetime, LogicalOffset]) -> List[confluent_kafka.TopicPartition]:
+                              position: Union[datetime, LogicalOffset]) \
+            -> List[confluent_kafka.TopicPartition]:
         if isinstance(position, datetime):
             offset = int(position.timestamp() * 1000)
         elif isinstance(position, LogicalOffset):
             offset = position
         else:
             raise TypeError("Only datetime objects and logical offsets supported")
-        
+
         _partitions = [
             confluent_kafka.TopicPartition(topic=tp.topic, partition=tp.partition, offset=offset)
             for tp in partitions
@@ -248,6 +252,7 @@ class Consumer:
         """ Close the consumer, ending its subscriptions. """
         self._consumer.close()
 
+
 # Used to be called ConsumerStartPosition, though this was confusing because
 # it only affects "auto.offset.reset" not the start position for a call to
 # consume.
@@ -258,9 +263,11 @@ class ConsumerDefaultPosition(enum.Enum):
     def __str__(self):
         return self.name.lower()
 
+
 # Alias to the old name
 # TODO: Remove alias on the next breaking release
 ConsumerStartPosition = ConsumerDefaultPosition
+
 
 @dataclasses.dataclass
 class ConsumerConfig:

--- a/adc/errors.py
+++ b/adc/errors.py
@@ -34,21 +34,69 @@ def log_delivery_errors(
 def raise_delivery_errors(kafka_error: confluent_kafka.KafkaError,
                           msg: confluent_kafka.Message) -> None:
     if kafka_error is not None:
-        raise KafkaException.from_kafka_error(kafka_error)
+        raise KafkaException.from_kafka_error(kafka_error, msg)
     elif msg.error() is not None:
-        raise KafkaException.from_kafka_error(msg.error())
+        raise KafkaException.from_kafka_error(msg.error(), msg)
+
+
+def _get_topic_related_errors():
+    """Build a set of all Kafka error codes which seem to relate to a specific topic.
+
+    This uses a list extracted from all documented error codes up to confluent_kafka v2.4,
+    but some of these errors did not exist or were not exposed in earlier versions.
+    To maintain backward compatibility, this function checks whether each error exists before
+    attempting to otherwise refer to it.
+    """
+    err_names = [
+        "_UNKNOWN_TOPIC",
+        "_NO_OFFSET",
+        "_LOG_TRUNCATION",
+        "OFFSET_OUT_OF_RANGE",
+        "UNKNOWN_TOPIC_OR_PART",
+        "NOT_LEADER_FOR_PARTITION",
+        "TOPIC_EXCEPTION",
+        "NOT_ENOUGH_REPLICAS",
+        "NOT_ENOUGH_REPLICAS_AFTER_APPEND",
+        "INVALID_COMMIT_OFFSET_SIZE",
+        "TOPIC_AUTHORIZATION_FAILED",
+        "TOPIC_ALREADY_EXISTS",
+        "INVALID_PARTITIONS",
+        "INVALID_REPLICATION_FACTOR",
+        "INVALID_REPLICA_ASSIGNMENT",
+        "REASSIGNMENT_IN_PROGRESS",
+        "TOPIC_DELETION_DISABLED",
+        "OFFSET_NOT_AVAILABLE",
+        "PREFERRED_LEADER_NOT_AVAILABLE",
+        "NO_REASSIGNMENT_IN_PROGRESS",
+        "GROUP_SUBSCRIBED_TO_TOPIC",
+        "UNSTABLE_OFFSET_COMMIT",
+        "UNKNOWN_TOPIC_ID",
+    ]
+    errors = set()
+    for name in err_names:
+        if hasattr(confluent_kafka.KafkaError, name):
+            errors.add(getattr(confluent_kafka.KafkaError, name))
+        else:
+            logger.debug(f"{name} does not exist in confluent_kafka version "
+                         f"{confluent_kafka.__version__} ({confluent_kafka.libversion()})")
+    return errors
 
 
 class KafkaException(Exception):
     @classmethod
-    def from_kafka_error(cls, error):
-        return cls(error)
+    def from_kafka_error(cls, error, msg=None):
+        return cls(error, msg)
 
-    def __init__(self, error):
+    topic_related_errors = _get_topic_related_errors()
+
+    def __init__(self, error, msg=None):
         self.error = error
         self.name = error.name()
         self.reason = error.str()
         self.retriable = error.retriable()
         self.fatal = error.fatal()
-        msg = f"Error communicating with Kafka: code={self.name} {self.reason}"
-        super(KafkaException, self).__init__(msg)
+        self.message = msg
+        ex_msg = f"Error communicating with Kafka: code={self.name} {self.reason}"
+        if msg and error.code() in KafkaException.topic_related_errors:
+            ex_msg += f" on topic {msg.topic()}"
+        super(KafkaException, self).__init__(ex_msg)

--- a/adc/oidc.py
+++ b/adc/oidc.py
@@ -18,7 +18,7 @@ def set_oauth_cb(config):
 
     from authlib.integrations.requests_client import OAuth2Session
     session = OAuth2Session(client_id, client_secret, scope=scope)
-    
+
     def oauth_cb(*_, **__):
         token = session.fetch_token(
             token_endpoint, grant_type='client_credentials')

--- a/adc/producer.py
+++ b/adc/producer.py
@@ -43,7 +43,7 @@ class Producer:
                 topic = self.conf.topic
             else:
                 raise Exception("No topic specified for write: "
-                                "Either configure a topic when consturcting the Producer, "
+                                "Either configure a topic when constructing the Producer, "
                                 "or specify the topic argument to write()")
         self.logger.debug("writing message to %s", topic)
         if delivery_callback is not None:

--- a/adc/producer.py
+++ b/adc/producer.py
@@ -1,9 +1,9 @@
 import abc
-from ast import comprehension
 import dataclasses
 import logging
 from datetime import timedelta
 from typing import Dict, List, Optional, Union
+
 try:  # this will work only in python >= 3.8
     from typing import Literal
 except ImportError:
@@ -112,7 +112,8 @@ class ProducerConfig:
     # between attempts to reconnect to Kafka.
     reconnect_max_time: timedelta = timedelta(seconds=10)
 
-    compression_type: Optional[Union[Literal['gzip'], Literal['snappy'], Literal['lz4'], Literal['zstd']]] = None
+    compression_type: Optional[Union[Literal['gzip'], Literal['snappy'],
+                                     Literal['lz4'], Literal['zstd']]] = None
 
     # maximum message size, before compression
     message_max_bytes: Optional[int] = None

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,3 +13,4 @@ exclude = setup.py,
 [tool:pytest]
 log_cli = True
 log_cli_level = INFO
+testpaths = tests


### PR DESCRIPTION
This patch makes setting a single topic for a `Producer` object optional, and enables the target topic to be specified when `write()` is called, so that one `Producer` can publish to multiple topics. Users who want the convenience of not having to specify the topic for each message when sending to only a single topic can use the interface unchanged, but this enables much improved efficiency for users who need to publish to multiple topics over having to create multiple `Producer`s (with a significant overhead in background threads and file descriptors). As currently implemented, the new logic is also lenient, such that even a `Producer` constructed with a specified topic will still allow the topic to be overridden on individual `write()` calls, if the user so chooses. 